### PR TITLE
Updating exception syntax for Python 3

### DIFF
--- a/nose_mongoengine/__init__.py
+++ b/nose_mongoengine/__init__.py
@@ -153,7 +153,7 @@ class MongoEnginePlugin(Plugin):
         try:
             db_file = open(db_log_path, "w")
             db_file.close()
-        except Exception, exc:
+        except Exception as exc:
             raise AssertionError("Invalid log path %r" % exc)
 
         if not options.mongodb_port:


### PR DESCRIPTION
Fix #1

According to http://docs.python.org/3/howto/pyporting.html#capturing-the-currently-raised-exception this fix will be compatible with Python 2.6 and up, including Python 3.
